### PR TITLE
Fix KeyboardInput adding repeated characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,9 +498,11 @@ impl Renderer {
                     (*(viewport.platform_user_data.cast::<ViewportData>())).focus = f;
                 },
                 winit::event::WindowEvent::KeyboardInput { ref event, .. } => {
-                    if let Some(txt) = &event.text {
-                        for ch in txt.chars() {
-                            imgui.io_mut().add_input_character(ch);
+                    if event.state.is_pressed() {
+                        if let Some(txt) = &event.text {
+                            for ch in txt.chars() {
+                                imgui.io_mut().add_input_character(ch);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fixes an issue where characters in text inputs are repeated. This was fixed in `imgui-winit-support` in [this](https://github.com/imgui-rs/imgui-winit-support/commit/aff79bd2fb09ab26f7c000d14d985880ef32b1ab) commit. I've just copied the changes from that commit into this repo.